### PR TITLE
pull request iss-integration-partial-log to feature/iss

### DIFF
--- a/src/mm/checkpoints.c
+++ b/src/mm/checkpoints.c
@@ -227,7 +227,10 @@ void *log_full(int lid) {
 	recoverable_state[lid]->total_inc_size = 0;
 
 	/// enable protection after log
-	run_model(lid);
+	if (recoverable_state[lid]->is_incremental) {
+		iss_update_model(lid);
+		iss_protect_memory(lid);
+	}
 
 	statistics_post_lp_data(lid, STAT_CKPT_TIME, (double)clock_timer_value(checkpoint_timer));
 	statistics_post_lp_data(lid, STAT_CKPT_MEM, (double)size);
@@ -469,8 +472,11 @@ void restore_full(int lid, void *ckpt) {
 	recoverable_state[lid]->total_inc_size = 0;
 
 	/// enable protection after restore
-	run_model(lid);
-
+	if (recoverable_state[lid]->is_incremental) {
+		iss_update_model(lid);
+		iss_protect_memory(lid);
+	}
+	
 	statistics_post_lp_data(lid, STAT_RECOVERY_TIME, (double)clock_timer_value(recovery_timer));
 }
 

--- a/src/mm/incremental_state_saving.h
+++ b/src/mm/incremental_state_saving.h
@@ -38,7 +38,8 @@ typedef struct __per_lp_iss_metadata{
 
 bool is_next_ckpt_incremental();
 
-void run_model(unsigned int cur_lp);
+void iss_update_model(unsigned int cur_lp);
+void iss_protect_memory(unsigned int cur_lp);
 
 partition_log* log_incremental(unsigned int cur_lp, simtime_t ts);
 void log_incremental_restore(unsigned int cur_lp, partition_log *cur);

--- a/src/mm/incremental_state_saving.h
+++ b/src/mm/incremental_state_saving.h
@@ -37,4 +37,9 @@ typedef struct __per_lp_iss_metadata{
 
 bool is_next_ckpt_incremental();
 
+void run_model(unsigned int cur_lp);
+
+partition_log* log_incremental(unsigned int cur_lp, simtime_t ts);
+void log_incremental_restore(unsigned int cur_lp, partition_log *cur);
+
 #endif

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -104,7 +104,7 @@ size_t get_log_size(malloc_state *logged_state){
 		return 0;
 
 	if (is_incremental(logged_state)) { 
-		return sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size;
+		return sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + sizeof(void *);
 	} else {
 		return sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
 	}


### PR DESCRIPTION
- file(checkpoints.c): added calls for incremental log and incremental restore and memory protection facilities
  method run_model is called at the end of log_full and restore_full

- file(incremental_state_saving.h): added signatures for exporting methods

- file(recoverable.c): enlarged the incremental log size (about sizeof(void * )) to make room for the partial log in log_full
