### PR TITLE
Iss config param

### DIFF
--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -248,7 +248,8 @@ void print_config(void){
     printf("\t\t|- period %u\n", pdes_config.ckpt_period);
     printf("\t\t|- autonomic %u\n", pdes_config.ckpt_autonomic_period);
     printf("\t\t|- collection %u\n", pdes_config.ckpt_collection_period);
-    printf("\t\t|- incremental with mprotect %u\n", pdes_config.iss_enabled_mprotection);
+    printf("\t\t|- ckpt mode %u\n", pdes_config.checkpointing);
+    printf("\t\t\t|- incremental with mprotect %u\n", pdes_config.iss_enabled_mprotection);
     printf("\t- ON_GVT MODE %u\n", pdes_config.ongvt_mode);
     printf("\t- ON_GVT PERIOD %u\n", pdes_config.ongvt_period);
     printf("\t- ENFORCE_LOCALITY %u\n", pdes_config.enforce_locality);

--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -99,7 +99,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       break;
 
     case ISS_ENABLED:
-      pdes_config.iss_enabled = 1;
+      pdes_config.checkpointing == INCREMENTAL_STATE_SAVING;
       break;
 
     case ISS_ENABLED_MPROTECTION:
@@ -215,7 +215,6 @@ void configuration_init(void){
   pdes_config.ckpt_collection_period = 100;
   pdes_config.ckpt_autonomic_period = 0;
   pdes_config.ckpt_forced_full_period = 0;
-  pdes_config.iss_enabled = 0;
   pdes_config.iss_enabled_mprotection = 0;
   pdes_config.serial = false;
   
@@ -249,8 +248,7 @@ void print_config(void){
     printf("\t\t|- period %u\n", pdes_config.ckpt_period);
     printf("\t\t|- autonomic %u\n", pdes_config.ckpt_autonomic_period);
     printf("\t\t|- collection %u\n", pdes_config.ckpt_collection_period);
-    printf("\t\t|- incremental %u\n", pdes_config.iss_enabled);
-    printf("\t\t\t|- with mprotect %u\n", pdes_config.iss_enabled_mprotection);
+    printf("\t\t|- incremental with mprotect %u\n", pdes_config.iss_enabled_mprotection);
     printf("\t- ON_GVT MODE %u\n", pdes_config.ongvt_mode);
     printf("\t- ON_GVT PERIOD %u\n", pdes_config.ongvt_period);
     printf("\t- ENFORCE_LOCALITY %u\n", pdes_config.enforce_locality);

--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -24,6 +24,8 @@ simulation_configuration pdes_config;
 #define CKPT_FOSSIL_PERIOD_KEY      362
 #define CKPT_AUTONOMIC_PERIOD_KEY   363
 #define CKPT_FORCED_FULL_PERIOD_KEY 364
+#define ISS_ENABLED                 365
+#define ISS_ENABLED_MPROTECTION     366
 
 #define DISTRIBUTED_FETCH_KEY       263
 #define NUMA_REBALANCE_KEY          264
@@ -49,7 +51,9 @@ static struct argp_option options[] = {
   {"ckpt-fossil-period",  CKPT_FOSSIL_PERIOD_KEY   , "#EVENTS" ,  0                  ,  "Number of events to be executed before collection committed snapshot"   , 0 },
   {"ckpt-autonomic-period",  CKPT_AUTONOMIC_PERIOD_KEY, 0         ,  OPTION_ARG_OPTIONAL,  "Enable autonomic checkpointing period"   , 0 },
   {"ckpt_forced_full_period",  CKPT_FORCED_FULL_PERIOD_KEY, "#CHECKPOINTS"         ,  0,  "Number of incremental checkpoints before taking a full log"   , 0 },
-  
+  {"iss_enabled",               ISS_ENABLED ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
+  {"iss_enabled_mprotection",   ISS_ENABLED_MPROTECTION ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
+ 
   {"distributed-fetch",   DISTRIBUTED_FETCH_KEY    , 0         ,  OPTION_ARG_OPTIONAL,  "Enable distributed fetch"   , 0 },
   {"numa-rebalance"   ,   NUMA_REBALANCE_KEY       , 0         ,  OPTION_ARG_OPTIONAL,  "Enable numa load-balancing"   , 0 },
   {"enable-mbind"       , ENABLE_MBIND_KEY         , 0         ,  OPTION_ARG_OPTIONAL,  "Enable mbind"   , 0 },
@@ -94,9 +98,17 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       pdes_config.ckpt_autonomic_period = 1;
       break;
 
+    case ISS_ENABLED:
+      pdes_config.iss_enabled = 1;
+      break;
+
+    case ISS_ENABLED_MPROTECTION:
+      pdes_config.iss_enabled_mprotection = 1;
+      break;
+
     case CKPT_FORCED_FULL_PERIOD_KEY:
       pdes_config.ckpt_forced_full_period = atoi(arg);
-      break;
+    break;
 
     case CKPT_FOSSIL_PERIOD_KEY:
       pdes_config.ckpt_collection_period = atoi(arg);
@@ -142,7 +154,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       break;
 
     case ARGP_KEY_END:
-      if(pdes_config.ckpt_period < 1 || pdes_config.ckpt_collection_period < 1){
+      if(pdes_config.ckpt_period < 1 || pdes_config.ckpt_collection_period < 1 || pdes_config.ckpt_forced_full_period < 1){
         printf("Please set a non-zero checkpoint period\n");
         argp_usage (state);  
       }
@@ -203,6 +215,8 @@ void configuration_init(void){
   pdes_config.ckpt_collection_period = 100;
   pdes_config.ckpt_autonomic_period = 0;
   pdes_config.ckpt_forced_full_period = 0;
+  pdes_config.iss_enabled = 0;
+  pdes_config.iss_enabled_mprotection = 0;
   pdes_config.serial = false;
   
   pdes_config.timeout = 0;
@@ -235,7 +249,8 @@ void print_config(void){
     printf("\t\t|- period %u\n", pdes_config.ckpt_period);
     printf("\t\t|- autonomic %u\n", pdes_config.ckpt_autonomic_period);
     printf("\t\t|- collection %u\n", pdes_config.ckpt_collection_period);
-    printf("\t\t|- incremental %u\n", pdes_config.ckpt_forced_full_period);
+    printf("\t\t|- incremental %u\n", pdes_config.iss_enabled);
+    printf("\t\t\t|- with mprotect %u\n", pdes_config.iss_enabled_mprotection);
     printf("\t- ON_GVT MODE %u\n", pdes_config.ongvt_mode);
     printf("\t- ON_GVT PERIOD %u\n", pdes_config.ongvt_period);
     printf("\t- ENFORCE_LOCALITY %u\n", pdes_config.enforce_locality);

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -34,6 +34,8 @@ typedef struct _simulation_configuration {
 	unsigned int ckpt_collection_period;
 	unsigned int ckpt_autonomic_period;
 	unsigned int ckpt_forced_full_period;
+	unsigned char iss_enabled;
+	unsigned char iss_enabled_mprotection;
 
 	unsigned int ongvt_period;
 	enum ongvt_mode ongvt_mode;

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -34,7 +34,6 @@ typedef struct _simulation_configuration {
 	unsigned int ckpt_collection_period;
 	unsigned int ckpt_autonomic_period;
 	unsigned int ckpt_forced_full_period;
-	unsigned char iss_enabled;
 	unsigned char iss_enabled_mprotection;
 
 	unsigned int ongvt_period;


### PR DESCRIPTION
file(configuration.c, configuration.h): defined cases ISS_ENABLED and ISS_ENABLED_PROTECTION and added associated parameters

* ISS_ENABLED determines whether the incremental state saving facility is enabled or not and sets pdes_config.checkpointing to INCREMENTAL_STATE_SAVING

* ISS_ENABLED_PROTECTION determines whether the incremental state saving is built statically or with the mprotect mechanism, 0 being static and 1 being with memory protection