### PR TITLE
Iss initialization

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -492,6 +492,10 @@ void init_simulation(unsigned int thread_id){
 		numerical_init();
 		nodes_init();
 
+		if (pdes_config.checkpointing == INCREMENTAL_STATE_SAVING) {
+			init_incremental_checkpoint_support(pdes_config.nprocesses);
+		}
+
 		if(pdes_config.enforce_locality){
 			pthread_barrier_init(&local_schedule_init_barrier, NULL, pdes_config.ncores);
 			init_metrics_for_window();
@@ -516,6 +520,10 @@ void init_simulation(unsigned int thread_id){
 		current_lp = __sync_fetch_and_add(&lp_inizialized, 1);
 		if(current_lp >=  pdes_config.nprocesses) continue;
 		if(!pdes_config.serial) allocator_init_for_lp(current_lp);
+		if (pdes_config.checkpointing == INCREMENTAL_STATE_SAVING){
+			init_incremental_checkpoint_support_per_lp(current_lp);
+		}
+
 		current_msg = list_allocate_node_buffer_from_list(current_lp, sizeof(msg_t), (struct rootsim_list*) freed_local_evts);
  		current_msg->sender_id 		= -1;//
  		current_msg->receiver_id 	= current_lp;//
@@ -531,6 +539,9 @@ void init_simulation(unsigned int thread_id){
 			LPS[current_lp]->bound = current_msg;
 			LPS[current_lp]->num_executed_frames++;
 			LPS[current_lp]->state_log_forced = true;
+			if (pdes_config.checkpointing == INCREMENTAL_STATE_SAVING) {
+				iss_first_run_model(current_lp);
+			}
 			LogState(current_lp);
 			((state_t*)((rootsim_list*)LPS[current_lp]->queue_states)->head->data)->lvt = -1;// Required to exclude the INIT event from timeline
 			LPS[current_lp]->state_log_forced = false;

--- a/src/mm/incremental_state_saving.h
+++ b/src/mm/incremental_state_saving.h
@@ -38,6 +38,10 @@ typedef struct __per_lp_iss_metadata{
 
 bool is_next_ckpt_incremental();
 
+void init_incremental_checkpoint_support(unsigned int num_lps);
+void init_incremental_checkpoint_support_per_lp(unsigned int lp);
+void iss_first_run_model(unsigned int cur_lp);
+
 void iss_update_model(unsigned int cur_lp);
 void iss_protect_memory(unsigned int cur_lp);
 


### PR DESCRIPTION
file(core.c): added init functions for incremental checkpointing

* init_incremental_checkpointing_support executed after nodes_init if INCREMENTAL_STATE_SAVING is enabled
* init_incremental_checkpoint_support_per_lp executed for each lp if INCREMENTAL_STATE_SAVING is enabled
* iss_first_run_model is executed for each lp before taking LogState after the first ProcessEvent