### PR TITLE
Pseudo di dymelor

### DIFF
--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -51,7 +51,6 @@ static struct argp_option options[] = {
   {"ckpt-fossil-period",  CKPT_FOSSIL_PERIOD_KEY   , "#EVENTS" ,  0                  ,  "Number of events to be executed before collection committed snapshot"   , 0 },
   {"ckpt-autonomic-period",  CKPT_AUTONOMIC_PERIOD_KEY, 0         ,  OPTION_ARG_OPTIONAL,  "Enable autonomic checkpointing period"   , 0 },
   {"ckpt_forced_full_period",  CKPT_FORCED_FULL_PERIOD_KEY, "#CHECKPOINTS"         ,  0,  "Number of incremental checkpoints before taking a full log"   , 0 },
-  {"iss_enabled",               ISS_ENABLED ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
   {"iss_enabled_mprotection",   ISS_ENABLED_MPROTECTION ,         0        ,  OPTION_ARG_OPTIONAL,  "Use mprotect as tracking mechanism for write accesses"   , 0 },
 
   {"distributed-fetch",   DISTRIBUTED_FETCH_KEY    , 0         ,  OPTION_ARG_OPTIONAL,  "Enable distributed fetch"   , 0 },
@@ -98,11 +97,8 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       pdes_config.ckpt_autonomic_period = 1;
       break;
 
-    case ISS_ENABLED:
-      pdes_config.checkpointing = INCREMENTAL_STATE_SAVING;
-      break;
-
     case ISS_ENABLED_MPROTECTION:
+      pdes_config.checkpointing = INCREMENTAL_STATE_SAVING;
       pdes_config.iss_enabled_mprotection = MPROTECT;
       break;
 
@@ -180,6 +176,10 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       }
       if(pdes_config.el_window_size != 0.0 && !pdes_config.enforce_locality){
         printf("Please enable enforce-locality to set starting window size\n");
+        argp_usage (state);
+      }
+      if(pdes_config.iss_enabled_mprotection == MPROTECT && pdes_config.checkpointing != INCREMENTAL_STATE_SAVING){
+        printf("Wrong configuration for checkpointing. It's not possible to have memory protection without incremental state saving\n");
         argp_usage (state);
       }
       if(pdes_config.ncores < 1)

--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -26,7 +26,6 @@ simulation_configuration pdes_config;
 #define CKPT_FORCED_FULL_PERIOD_KEY 364
 #define ISS_ENABLED                 365
 #define ISS_ENABLED_MPROTECTION     366
-#define MEM_SUPPORT_LOG             367
 
 #define DISTRIBUTED_FETCH_KEY       263
 #define NUMA_REBALANCE_KEY          264
@@ -53,6 +52,7 @@ static struct argp_option options[] = {
   {"ckpt-autonomic-period",  CKPT_AUTONOMIC_PERIOD_KEY, 0         ,  OPTION_ARG_OPTIONAL,  "Enable autonomic checkpointing period"   , 0 },
   {"ckpt_forced_full_period",  CKPT_FORCED_FULL_PERIOD_KEY, "#CHECKPOINTS"         ,  0,  "Number of incremental checkpoints before taking a full log"   , 0 },
   {"iss_enabled",               ISS_ENABLED ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
+  {"iss_enabled_mprotection",   ISS_ENABLED_MPROTECTION ,         0        ,  OPTION_ARG_OPTIONAL,  "Use mprotect as tracking mechanism for write accesses"   , 0 },
 
   {"distributed-fetch",   DISTRIBUTED_FETCH_KEY    , 0         ,  OPTION_ARG_OPTIONAL,  "Enable distributed fetch"   , 0 },
   {"numa-rebalance"   ,   NUMA_REBALANCE_KEY       , 0         ,  OPTION_ARG_OPTIONAL,  "Enable numa load-balancing"   , 0 },

--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -102,6 +102,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 
     case ISS_ENABLED:
       pdes_config.checkpointing = INCREMENTAL_STATE_SAVING;
+      pdes_config.iss_enabled   = 1;
       break;
 
     case ISS_ENABLED_MPROTECTION:
@@ -221,8 +222,9 @@ void configuration_init(void){
   pdes_config.ckpt_collection_period = 100;
   pdes_config.ckpt_autonomic_period = 0;
   pdes_config.ckpt_forced_full_period = 1;
+  pdes_config.iss_enabled             = 0;
   pdes_config.iss_enabled_mprotection = 0;
-  pdes_config.mem_support_log = 0; 
+  pdes_config.mem_support_log         = 0; 
   pdes_config.serial = false;
   
   pdes_config.timeout = 0;
@@ -257,6 +259,7 @@ void print_config(void){
     printf("\t\t|- collection %u\n", pdes_config.ckpt_collection_period);
     printf("\t\t - memory subsystem support %u\n", pdes_config.mem_support_log);
     printf("\t\t|- ckpt mode %u\n", pdes_config.checkpointing);
+    printf("\t\t|- incremental ckpt %u\n", pdes_config.iss_enabled);
     printf("\t\t\t|- incremental with mprotect %u\n", pdes_config.iss_enabled_mprotection);
     printf("\t- ON_GVT MODE %u\n", pdes_config.ongvt_mode);
     printf("\t- ON_GVT PERIOD %u\n", pdes_config.ongvt_period);

--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -26,6 +26,7 @@ simulation_configuration pdes_config;
 #define CKPT_FORCED_FULL_PERIOD_KEY 364
 #define ISS_ENABLED                 365
 #define ISS_ENABLED_MPROTECTION     366
+#define MEM_SUPPORT_LOG             367
 
 #define DISTRIBUTED_FETCH_KEY       263
 #define NUMA_REBALANCE_KEY          264
@@ -53,7 +54,8 @@ static struct argp_option options[] = {
   {"ckpt_forced_full_period",  CKPT_FORCED_FULL_PERIOD_KEY, "#CHECKPOINTS"         ,  0,  "Number of incremental checkpoints before taking a full log"   , 0 },
   {"iss_enabled",               ISS_ENABLED ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
   {"iss_enabled_mprotection",   ISS_ENABLED_MPROTECTION ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
- 
+  {"mem_support_log",   MEM_SUPPORT_LOG ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
+
   {"distributed-fetch",   DISTRIBUTED_FETCH_KEY    , 0         ,  OPTION_ARG_OPTIONAL,  "Enable distributed fetch"   , 0 },
   {"numa-rebalance"   ,   NUMA_REBALANCE_KEY       , 0         ,  OPTION_ARG_OPTIONAL,  "Enable numa load-balancing"   , 0 },
   {"enable-mbind"       , ENABLE_MBIND_KEY         , 0         ,  OPTION_ARG_OPTIONAL,  "Enable mbind"   , 0 },
@@ -104,6 +106,10 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 
     case ISS_ENABLED_MPROTECTION:
       pdes_config.iss_enabled_mprotection = 1;
+      break;
+
+    case MEM_SUPPORT_LOG:
+      pdes_config.mem_support_log = 1; /// 1 being di-dymelor
       break;
 
     case CKPT_FORCED_FULL_PERIOD_KEY:
@@ -216,6 +222,7 @@ void configuration_init(void){
   pdes_config.ckpt_autonomic_period = 0;
   pdes_config.ckpt_forced_full_period = 1;
   pdes_config.iss_enabled_mprotection = 0;
+  pdes_config.mem_support_log = 0; 
   pdes_config.serial = false;
   
   pdes_config.timeout = 0;
@@ -248,6 +255,7 @@ void print_config(void){
     printf("\t\t|- period %u\n", pdes_config.ckpt_period);
     printf("\t\t|- autonomic %u\n", pdes_config.ckpt_autonomic_period);
     printf("\t\t|- collection %u\n", pdes_config.ckpt_collection_period);
+    printf("\t\t - memory subsystem support %u\n", pdes_config.mem_support_log);
     printf("\t\t|- ckpt mode %u\n", pdes_config.checkpointing);
     printf("\t\t\t|- incremental with mprotect %u\n", pdes_config.iss_enabled_mprotection);
     printf("\t- ON_GVT MODE %u\n", pdes_config.ongvt_mode);

--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -53,8 +53,6 @@ static struct argp_option options[] = {
   {"ckpt-autonomic-period",  CKPT_AUTONOMIC_PERIOD_KEY, 0         ,  OPTION_ARG_OPTIONAL,  "Enable autonomic checkpointing period"   , 0 },
   {"ckpt_forced_full_period",  CKPT_FORCED_FULL_PERIOD_KEY, "#CHECKPOINTS"         ,  0,  "Number of incremental checkpoints before taking a full log"   , 0 },
   {"iss_enabled",               ISS_ENABLED ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
-  {"iss_enabled_mprotection",   ISS_ENABLED_MPROTECTION ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
-  {"mem_support_log",   MEM_SUPPORT_LOG ,         0        ,  OPTION_ARG_OPTIONAL,  "Use incremental state saving as checkpointing mechanism"   , 0 },
 
   {"distributed-fetch",   DISTRIBUTED_FETCH_KEY    , 0         ,  OPTION_ARG_OPTIONAL,  "Enable distributed fetch"   , 0 },
   {"numa-rebalance"   ,   NUMA_REBALANCE_KEY       , 0         ,  OPTION_ARG_OPTIONAL,  "Enable numa load-balancing"   , 0 },
@@ -102,15 +100,10 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 
     case ISS_ENABLED:
       pdes_config.checkpointing = INCREMENTAL_STATE_SAVING;
-      pdes_config.iss_enabled   = 1;
       break;
 
     case ISS_ENABLED_MPROTECTION:
-      pdes_config.iss_enabled_mprotection = 1;
-      break;
-
-    case MEM_SUPPORT_LOG:
-      pdes_config.mem_support_log = 1; /// 1 being di-dymelor
+      pdes_config.iss_enabled_mprotection = MPROTECT;
       break;
 
     case CKPT_FORCED_FULL_PERIOD_KEY:
@@ -222,9 +215,7 @@ void configuration_init(void){
   pdes_config.ckpt_collection_period = 100;
   pdes_config.ckpt_autonomic_period = 0;
   pdes_config.ckpt_forced_full_period = 1;
-  pdes_config.iss_enabled             = 0;
-  pdes_config.iss_enabled_mprotection = 0;
-  pdes_config.mem_support_log         = 0; 
+  pdes_config.iss_enabled_mprotection = DDYMELOR;
   pdes_config.serial = false;
   
   pdes_config.timeout = 0;
@@ -257,9 +248,7 @@ void print_config(void){
     printf("\t\t|- period %u\n", pdes_config.ckpt_period);
     printf("\t\t|- autonomic %u\n", pdes_config.ckpt_autonomic_period);
     printf("\t\t|- collection %u\n", pdes_config.ckpt_collection_period);
-    printf("\t\t - memory subsystem support %u\n", pdes_config.mem_support_log);
     printf("\t\t|- ckpt mode %u\n", pdes_config.checkpointing);
-    printf("\t\t|- incremental ckpt %u\n", pdes_config.iss_enabled);
     printf("\t\t\t|- incremental with mprotect %u\n", pdes_config.iss_enabled_mprotection);
     printf("\t- ON_GVT MODE %u\n", pdes_config.ongvt_mode);
     printf("\t- ON_GVT PERIOD %u\n", pdes_config.ongvt_period);

--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -25,7 +25,7 @@ simulation_configuration pdes_config;
 #define CKPT_AUTONOMIC_PERIOD_KEY   363
 #define CKPT_FORCED_FULL_PERIOD_KEY 364
 #define ISS_ENABLED                 365
-#define ISS_ENABLED_MPROTECTION     366
+#define ISS_MODE                    366
 
 #define DISTRIBUTED_FETCH_KEY       263
 #define NUMA_REBALANCE_KEY          264
@@ -51,7 +51,7 @@ static struct argp_option options[] = {
   {"ckpt-fossil-period",  CKPT_FOSSIL_PERIOD_KEY   , "#EVENTS" ,  0                  ,  "Number of events to be executed before collection committed snapshot"   , 0 },
   {"ckpt-autonomic-period",  CKPT_AUTONOMIC_PERIOD_KEY, 0         ,  OPTION_ARG_OPTIONAL,  "Enable autonomic checkpointing period"   , 0 },
   {"ckpt_forced_full_period",  CKPT_FORCED_FULL_PERIOD_KEY, "#CHECKPOINTS"         ,  0,  "Number of incremental checkpoints before taking a full log"   , 0 },
-  {"iss_enabled_mprotection",   ISS_ENABLED_MPROTECTION ,         0        ,  OPTION_ARG_OPTIONAL,  "Use mprotect as tracking mechanism for write accesses"   , 0 },
+  {"iss_mode",                ISS_MODE ,         0        ,  OPTION_ARG_OPTIONAL,  "Use mprotect as tracking mechanism for write accesses"   , 0 },
 
   {"distributed-fetch",   DISTRIBUTED_FETCH_KEY    , 0         ,  OPTION_ARG_OPTIONAL,  "Enable distributed fetch"   , 0 },
   {"numa-rebalance"   ,   NUMA_REBALANCE_KEY       , 0         ,  OPTION_ARG_OPTIONAL,  "Enable numa load-balancing"   , 0 },
@@ -97,9 +97,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       pdes_config.ckpt_autonomic_period = 1;
       break;
 
-    case ISS_ENABLED_MPROTECTION:
+    case ISS_MODE:
       pdes_config.checkpointing = INCREMENTAL_STATE_SAVING;
-      pdes_config.iss_enabled_mprotection = MPROTECT;
+      pdes_config.iss_mode = MPROTECT;
       break;
 
     case CKPT_FORCED_FULL_PERIOD_KEY:
@@ -178,7 +178,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
         printf("Please enable enforce-locality to set starting window size\n");
         argp_usage (state);
       }
-      if(pdes_config.iss_enabled_mprotection == MPROTECT && pdes_config.checkpointing != INCREMENTAL_STATE_SAVING){
+      if(pdes_config.iss_mode == MPROTECT && pdes_config.checkpointing != INCREMENTAL_STATE_SAVING){
         printf("Wrong configuration for checkpointing. It's not possible to have memory protection without incremental state saving\n");
         argp_usage (state);
       }
@@ -215,7 +215,7 @@ void configuration_init(void){
   pdes_config.ckpt_collection_period = 100;
   pdes_config.ckpt_autonomic_period = 0;
   pdes_config.ckpt_forced_full_period = 1;
-  pdes_config.iss_enabled_mprotection = DDYMELOR;
+  pdes_config.iss_mode = DDYMELOR;
   pdes_config.serial = false;
   
   pdes_config.timeout = 0;
@@ -249,7 +249,7 @@ void print_config(void){
     printf("\t\t|- autonomic %u\n", pdes_config.ckpt_autonomic_period);
     printf("\t\t|- collection %u\n", pdes_config.ckpt_collection_period);
     printf("\t\t|- ckpt mode %u\n", pdes_config.checkpointing);
-    printf("\t\t\t|- incremental with mprotect %u\n", pdes_config.iss_enabled_mprotection);
+    printf("\t\t\t|- incremental with mprotect %u\n", pdes_config.iss_mode);
     printf("\t- ON_GVT MODE %u\n", pdes_config.ongvt_mode);
     printf("\t- ON_GVT PERIOD %u\n", pdes_config.ongvt_period);
     printf("\t- ENFORCE_LOCALITY %u\n", pdes_config.enforce_locality);

--- a/src/include/ROOT-Sim.h
+++ b/src/include/ROOT-Sim.h
@@ -144,8 +144,15 @@ int Zipf(double skew, int limit);
 
 
 extern void dirty(void*, size_t);
+extern void set_chunk_dirty_from_address(void *, int);
 
-#define MODEL_WRITE(var,val)  do{ dirty(&(var), sizeof((var)));(var) = (val);}while(0)
+#define MODEL_WRITE(var,val)({\
+		if (pdes_config.iss_enabled_mprotection == MPROTECT) {\
+			do{ dirty(&(var), sizeof((var)));(var) = (val);} while(0);\
+		}else {\
+			do { set_chunk_dirty_from_address(&(var), val); (var) = (val); } while (0);\
+		}\
+		})
 
 
 

--- a/src/include/ROOT-Sim.h
+++ b/src/include/ROOT-Sim.h
@@ -147,7 +147,7 @@ extern void dirty(void*, size_t);
 extern void set_chunk_dirty_from_address(void *, int);
 
 #define MODEL_WRITE(var,val)({\
-		if (pdes_config.iss_enabled_mprotection == MPROTECT) {\
+		if (pdes_config.iss_mode == MPROTECT) {\
 			do{ dirty(&(var), sizeof((var)));(var) = (val);} while(0);\
 		}else {\
 			do { set_chunk_dirty_from_address(&(var), val); (var) = (val); } while (0);\

--- a/src/include/ROOT-Sim.h
+++ b/src/include/ROOT-Sim.h
@@ -147,10 +147,12 @@ extern void dirty(void*, size_t);
 extern void set_chunk_dirty_from_address(void *, int);
 
 #define MODEL_WRITE(var,val)({\
-		if (pdes_config.iss_mode == MPROTECT) {\
-			do{ dirty(&(var), sizeof((var)));(var) = (val);} while(0);\
-		}else {\
-			do { set_chunk_dirty_from_address(&(var), val); (var) = (val); } while (0);\
+		if(pdes_config.checkpointing == INCREMENTAL_STATE_SAVING){\
+			if (pdes_config.iss_mode == MPROTECT) {\
+				do{ dirty(&(var), sizeof((var)));(var) = (val);} while(0);\
+			}else {\
+				do { set_chunk_dirty_from_address(&(var), val); (var) = (val); } while (0);\
+			}\
 		}\
 		})
 

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -39,7 +39,7 @@ typedef struct _simulation_configuration {
 	unsigned int ckpt_collection_period;
 	unsigned int ckpt_autonomic_period;
 	unsigned int ckpt_forced_full_period;
-	enum iss_mode iss_enabled_mprotection;
+	enum iss_mode iss_mode;
 
 	unsigned int ongvt_period;
 	enum ongvt_mode ongvt_mode;

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -35,6 +35,7 @@ typedef struct _simulation_configuration {
 	unsigned int ckpt_autonomic_period;
 	unsigned int ckpt_forced_full_period;
 	unsigned char iss_enabled_mprotection;
+	unsigned int mem_support_log;
 
 	unsigned int ongvt_period;
 	enum ongvt_mode ongvt_mode;

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -34,6 +34,7 @@ typedef struct _simulation_configuration {
 	unsigned int ckpt_collection_period;
 	unsigned int ckpt_autonomic_period;
 	unsigned int ckpt_forced_full_period;
+	unsigned char iss_enabled;
 	unsigned char iss_enabled_mprotection;
 	unsigned int mem_support_log;
 

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -20,6 +20,11 @@ PERIODIC_STATE_SAVING,		/// Periodic State Saving checkpointing interval
 INCREMENTAL_STATE_SAVING /// Incremental state saving mode
 };
 
+enum iss_mode{
+MPROTECT, /// incremental state saving supported by memory protection
+DDYMELOR /// incremental state saving supported by di-dymelor
+};
+
 
 
 typedef struct _simulation_configuration {
@@ -34,9 +39,7 @@ typedef struct _simulation_configuration {
 	unsigned int ckpt_collection_period;
 	unsigned int ckpt_autonomic_period;
 	unsigned int ckpt_forced_full_period;
-	unsigned char iss_enabled;
-	unsigned char iss_enabled_mprotection;
-	unsigned int mem_support_log;
+	enum iss_mode iss_enabled_mprotection;
 
 	unsigned int ongvt_period;
 	enum ongvt_mode ongvt_mode;

--- a/src/mm/checkpoints.c
+++ b/src/mm/checkpoints.c
@@ -622,7 +622,7 @@ void log_delete(void *ckpt){
 		if(((malloc_state*)ckpt)->is_incremental){
 				tmp = (void*)((char*)ckpt + sizeof(malloc_state));
 				tmp = (void *)((char *)tmp + sizeof(seed_type));
-				log_incremental_destroy_chain(*(partition_log**)tmp);
+				if (!pdes_config.mem_support_log) log_incremental_destroy_chain(*(partition_log**)tmp);
 		}
 		rsfree(ckpt);
 	}

--- a/src/mm/checkpoints.c
+++ b/src/mm/checkpoints.c
@@ -92,14 +92,14 @@ void set_chunk_dirty_from_address(void *addr, int lp) {
 	
 }
 
-void clean_bitmap(unsigned int *use_bitmap, int blocks, unsigned int **bitmap) {
+void clean_bitmap(int blocks, unsigned int *bitmap) {
 
 	int j;
-	if (use_bitmap != NULL) {
+	if (bitmap != NULL) {
 		for(j = 0; j < blocks; j++)
-			*bitmap[j] = 0;
+			bitmap[j] = 0;
+		
 	}
-
 }
 
 

--- a/src/mm/checkpoints.c
+++ b/src/mm/checkpoints.c
@@ -131,7 +131,9 @@ void set_chunk_dirty_from_address(void *addr, int lp) {
 	
 }
 
-void clean_bitmap(int blocks, unsigned int *bitmap) { bzero((void *)bitmap, blocks * BLOCK_SIZE); }
+void clean_bitmap(int blocks, unsigned int *bitmap) { 
+	if (bitmap != NULL) bzero((void *) bitmap, blocks * BLOCK_SIZE); 
+}
 
 
 bool check_not_used_chunk_and_clean(malloc_area *m_area, int blocks) {

--- a/src/mm/checkpoints.c
+++ b/src/mm/checkpoints.c
@@ -74,6 +74,8 @@ void set_chunk_dirty_from_address(void *addr, int lp) {
 	for (j=0; j < num_areas; j++) {
 		num_chunks = areas[j].num_chunks;
 		chunk_size = areas[j].chunk_size;
+		RESET_BIT_AT(chunk_size, 0);	// ckpt Mode bit
+		RESET_BIT_AT(chunk_size, 1);	// Lock bit
 		blocks = compute_bitmap_blocks(num_chunks);
 		area_size = num_chunks * chunk_size;
 		marea_base_addr = ((unsigned long long) areas[j].area); 
@@ -82,6 +84,7 @@ void set_chunk_dirty_from_address(void *addr, int lp) {
 			offset = start_address - marea_base_addr;
 			index = offset / chunk_size;
 			SET_DIRTY_BIT(target_marea, index); 
+			target_marea->dirty_chunks++;
 			break;
 		}
 	}

--- a/src/mm/checkpoints.c
+++ b/src/mm/checkpoints.c
@@ -168,12 +168,13 @@ void log_all_marea_chunks(malloc_area *m_area, void **ptr, int bitmap_blocks, in
 
 	} else {
 		
-		copy_chunks_in_marea(m_area, m_area->use_bitmap, bitmap_blocks, ptr, chunk_size);
 
 		if (is_incremental) {
-			memcpy(*ptr, m_area->dirty_bitmap, dirty_blocks * BLOCK_SIZE);
-			*ptr = (void*)((char*) *ptr + dirty_blocks * BLOCK_SIZE);
-			copy_chunks_in_marea(m_area, m_area->dirty_bitmap, dirty_blocks, ptr, chunk_size);
+			memcpy(*ptr, m_area->dirty_bitmap, bitmap_blocks * BLOCK_SIZE);
+			*ptr = (void*)((char*) *ptr + bitmap_blocks * BLOCK_SIZE);
+			copy_chunks_in_marea(m_area, m_area->dirty_bitmap, bitmap_blocks, ptr, chunk_size);
+		} else {
+			copy_chunks_in_marea(m_area, m_area->use_bitmap, bitmap_blocks, ptr, chunk_size);
 		}
 
 	}
@@ -413,12 +414,14 @@ void restore_marea_chunk(malloc_area *m_area, void **ptr, int bitmap_blocks, int
 		// The area was partially logged.
 		// Logged chunks are the ones associated with a used bit whose value is 1
 		// Their number is in the alloc_chunks counter
-		restore_chunks_in_marea(m_area, m_area->use_bitmap, bitmap_blocks, ptr, chunk_size);
+		
 
 		if (is_incremental) {
-			memcpy(m_area->dirty_bitmap, *ptr, dirty_blocks * BLOCK_SIZE);
-			*ptr = (void*)((char*) *ptr + dirty_blocks * BLOCK_SIZE);
-			restore_chunks_in_marea(m_area, m_area->dirty_bitmap, dirty_blocks, ptr, chunk_size);
+			memcpy(m_area->dirty_bitmap, *ptr, bitmap_blocks * BLOCK_SIZE);
+			*ptr = (void*)((char*) *ptr + bitmap_blocks * BLOCK_SIZE);
+			restore_chunks_in_marea(m_area, m_area->dirty_bitmap, bitmap_blocks, ptr, chunk_size);
+		} else {
+			restore_chunks_in_marea(m_area, m_area->use_bitmap, bitmap_blocks, ptr, chunk_size);
 		}
 		
 	}

--- a/src/mm/checkpoints.c
+++ b/src/mm/checkpoints.c
@@ -103,7 +103,7 @@ void clean_bitmap(unsigned int *use_bitmap, int blocks, unsigned int **bitmap) {
 }
 
 
-bool check_not_used_chunk_and_clean(malloc_area *m_area, int dirty_blocks) {
+bool check_not_used_chunk_and_clean(malloc_area *m_area, int blocks) {
 
 
 	// Check if there is at least one chunk used in the area
@@ -112,7 +112,7 @@ bool check_not_used_chunk_and_clean(malloc_area *m_area, int dirty_blocks) {
 		m_area->dirty_chunks = 0;
 		m_area->state_changed = 0;
 
-		clean_bitmap(m_area->use_bitmap, dirty_blocks, &(m_area->dirty_bitmap));
+		clean_bitmap(m_area->use_bitmap, blocks, &(m_area->dirty_bitmap));
 		
 		return true; /// do not log this area skip to the next one
 	}

--- a/src/mm/dymelor.h
+++ b/src/mm/dymelor.h
@@ -87,6 +87,9 @@
 // This macro is used to retrieve a cache line in O(1)
 #define GET_CACHE_LINE_NUMBER(P) ((unsigned long)((P >> 4) & (CACHE_SIZE - 1)))
 
+/// Macro used to get the chunk_size for a given m_area
+#define GET_AREA_CHUNK_SIZE(x) ((x).chunk_size & (~3))
+
 // Macros to check, set and unset bits in the malloc_area masks
 #define CHECK_USE_BIT(A,I) ( CHECK_BIT_AT(									\
 			((unsigned int*)(((malloc_area*)A)->use_bitmap))[(int)((int)I / NUM_CHUNKS_PER_BLOCK)],	\

--- a/src/mm/incremental_state_saving.c
+++ b/src/mm/incremental_state_saving.c
@@ -18,14 +18,14 @@ model_t iss_costs_model;	 /// runtime tuning of the cost model
 
 
 static inline void guard_memory(void* pg_ptr, size_t size){
-	if(!pdes_config.iss_enabled_mprotection) return;
+	if(!pdes_config.iss_mode) return;
 	assert(pg_ptr >= mem_areas[current_lp] && pg_ptr < mem_areas[current_lp]+PER_LP_PREALLOCATED_MEMORY);
 	assert(size <= PER_LP_PREALLOCATED_MEMORY);
 	mprotect(pg_ptr, size, PROT_READ);
 }
 
 static inline void unguard_memory(void* pg_ptr, size_t size){
-	if(!pdes_config.iss_enabled_mprotection) return;
+	if(!pdes_config.iss_mode) return;
 	assert(pg_ptr >= mem_areas[current_lp] && pg_ptr < mem_areas[current_lp]+PER_LP_PREALLOCATED_MEMORY);
 	assert(size <= PER_LP_PREALLOCATED_MEMORY);
 	mprotect(pg_ptr, size, PROT_READ | PROT_WRITE);

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -105,12 +105,12 @@ size_t get_log_size(malloc_state *logged_state){
 
 	size_t log_size;
 
-	if (!pdes_config.iss_enabled) {
+	if (!pdes_config.checkpointing == INCREMENTAL_STATE_SAVING) {
 		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
 
 	} else {
 
-		if (!pdes_config.iss_enabled_mprotection) {
+		if (pdes_config.iss_enabled_mprotection == DDYMELOR) {
 
 			if (!is_incremental(logged_state)) {
 				log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;;

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -109,7 +109,7 @@ size_t get_log_size(malloc_state *logged_state){
 		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
 	} else {
 
-		if (pdes_config.iss_enabled_mprotection == DDYMELOR) {
+		if (pdes_config.iss_mode == DDYMELOR) {
 			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->dirty_areas * sizeof(malloc_area) + logged_state->bitmap_size*2 + logged_state->total_inc_size;
 		} else {
 			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + sizeof(void *);

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -103,12 +103,17 @@ size_t get_log_size(malloc_state *logged_state){
 	if (logged_state == NULL)
 		return 0;
 
+	size_t log_size;
+
 	if (is_incremental(logged_state)) { 
-		return sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + sizeof(void *);
+		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + sizeof(void *);
+		if (pdes_config.iss_enabled_mprotection) log_size += (logged_state->dirty_bitmap_size + logged_state->dirty_areas * sizeof(malloc_area));
 	} else {
-		return sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
+		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
+		if (pdes_config.iss_enabled_mprotection) log_size += (logged_state->dirty_bitmap_size + logged_state->dirty_areas * sizeof(malloc_area));
 	}
 
+	return log_size;
 }
 
 

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -105,7 +105,7 @@ size_t get_log_size(malloc_state *logged_state){
 
 	size_t log_size;
 
-	if (!(pdes_config.checkpointing == INCREMENTAL_STATE_SAVING) || !logged_state->is_incremental) {
+	if (!logged_state->is_incremental) {
 		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
 	} else {
 

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -105,18 +105,14 @@ size_t get_log_size(malloc_state *logged_state){
 
 	size_t log_size;
 
-	if (!pdes_config.checkpointing == INCREMENTAL_STATE_SAVING || !logged_state->is_incremental) {
+	if (!(pdes_config.checkpointing == INCREMENTAL_STATE_SAVING) || !logged_state->is_incremental) {
 		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
-
 	} else {
 
 		if (pdes_config.iss_enabled_mprotection == DDYMELOR) {
-
 			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->dirty_areas * sizeof(malloc_area) + logged_state->bitmap_size*2 + logged_state->total_inc_size;
-			
 		} else {
-			
-			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size;
+			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + sizeof(void *);
 		}
 	}
 

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -105,22 +105,18 @@ size_t get_log_size(malloc_state *logged_state){
 
 	size_t log_size;
 
-	if (!pdes_config.checkpointing == INCREMENTAL_STATE_SAVING) {
+	if (!pdes_config.checkpointing == INCREMENTAL_STATE_SAVING || !logged_state->is_incremental) {
 		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
 
 	} else {
 
 		if (pdes_config.iss_enabled_mprotection == DDYMELOR) {
 
-			if (!is_incremental(logged_state)) {
-				log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;;
-			} else { 
-				log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size;
-			}
-
+			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->dirty_areas * sizeof(malloc_area) + logged_state->bitmap_size*2 + logged_state->total_inc_size;
+			
 		} else {
-
-			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size * 2 + logged_state->total_log_size + logged_state->dirty_areas * sizeof(malloc_area);
+			
+			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size;
 		}
 	}
 

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -105,19 +105,23 @@ size_t get_log_size(malloc_state *logged_state){
 
 	size_t log_size;
 
-	if (is_incremental(logged_state)) { 
+	if (!pdes_config.iss_enabled) {
+		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
 
-		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + sizeof(void *);
-		
-		if (pdes_config.mem_support_log && pdes_config.iss_enabled_mprotection) {
-			log_size += (logged_state->dirty_bitmap_size + logged_state->dirty_areas * sizeof(malloc_area));
-		}
-	
 	} else {
 
-		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
-		
-		if (pdes_config.iss_enabled_mprotection) log_size += (logged_state->dirty_bitmap_size + logged_state->dirty_areas * sizeof(malloc_area));
+		if (!pdes_config.iss_enabled_mprotection) {
+
+			if (!is_incremental(logged_state)) {
+				log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;;
+			} else { 
+				log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size;
+			}
+
+		} else {
+
+			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size * 2 + logged_state->total_log_size + logged_state->dirty_areas * sizeof(malloc_area);
+		}
 	}
 
 	return log_size;

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -106,10 +106,17 @@ size_t get_log_size(malloc_state *logged_state){
 	size_t log_size;
 
 	if (is_incremental(logged_state)) { 
+
 		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + sizeof(void *);
-		if (pdes_config.iss_enabled_mprotection) log_size += (logged_state->dirty_bitmap_size + logged_state->dirty_areas * sizeof(malloc_area));
+		
+		if (pdes_config.mem_support_log && pdes_config.iss_enabled_mprotection) {
+			log_size += (logged_state->dirty_bitmap_size + logged_state->dirty_areas * sizeof(malloc_area));
+		}
+	
 	} else {
+
 		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
+		
 		if (pdes_config.iss_enabled_mprotection) log_size += (logged_state->dirty_bitmap_size + logged_state->dirty_areas * sizeof(malloc_area));
 	}
 

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -107,10 +107,11 @@ size_t get_log_size(malloc_state *logged_state){
 
 	if (!logged_state->is_incremental) {
 		log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size;
+
 	} else {
 
 		if (pdes_config.iss_mode == DDYMELOR) {
-			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->dirty_areas * sizeof(malloc_area) + logged_state->bitmap_size*2 + logged_state->total_inc_size;
+			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->dirty_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->dirty_bitmap_size + logged_state->total_inc_size;
 		} else {
 			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + sizeof(void *);
 		}

--- a/src/statistics/statistics.c
+++ b/src/statistics/statistics.c
@@ -387,6 +387,7 @@ static void _print_statistics(struct stats_t *stats) {
 	printf("\n");
 
 	printf("Save Checkpoint operations......................: %12llu\n", (unsigned long long)stats->counter_checkpoints);
+	printf("Save Full Checkpoint operations.................: %12llu\n", (unsigned long long)stats->counter_checkpoints - (unsigned long long)stats->counter_checkpoints_iss);
 	printf("Save Incremental Checkpoint operations..........: %12llu\n", (unsigned long long)stats->counter_checkpoints_iss);
 	printf("Restore Checkpoint operations...................: %12llu\n", (unsigned long long)stats->counter_recoveries);
 	printf("Incremental Restore Checkpoint operations.......: %12llu\n", (unsigned long long)stats->counter_restore_iss);

--- a/src/statistics/statistics.c
+++ b/src/statistics/statistics.c
@@ -119,12 +119,24 @@ static void statistics_post_data(struct stats_t *stats, int idx, int type, stat6
 			stats[idx].counter_checkpoints += value;
 			break;
 
+		case STAT_INC_CKPT:
+			stats[idx].counter_checkpoints_iss += value;
+			break;
+
 		case STAT_CKPT_MEM:
 			stats[idx].mem_checkpoint += value;
 			break;
 
+		case STAT_INC_CKPT_MEM:
+			stats[idx].mem_checkpoint_iss += value;
+			break;
+
 		case STAT_RECOVERY:
 			stats[idx].counter_recoveries += value;
+			break;
+
+		case STAT_INC_RESTORE:
+			stats[idx].counter_restore_iss += value;
 			break;
 
 		// ========= TIME STATS ========= //
@@ -156,8 +168,16 @@ static void statistics_post_data(struct stats_t *stats, int idx, int type, stat6
 			stats[idx].clock_checkpoint += value;
 			break;
 
+		case STAT_INC_CKPT_TIME:
+			stats[idx].clock_checkpoint_iss += value;
+			break;
+
 		case STAT_RECOVERY_TIME:
 			stats[idx].clock_recovery += value;
+			break;
+
+		case STAT_INC_RECOVERY_TIME:
+			stats[idx].clock_recovery_iss += value;
 			break;
 
 		case STAT_CLOCK_FETCH_SUCC:
@@ -240,7 +260,9 @@ void gather_statistics() {
 		system_stats->events_anti          += lp_stats[i].events_anti;
 		
 		system_stats->counter_checkpoints  += lp_stats[i].counter_checkpoints;
+		system_stats->counter_checkpoints_iss  += lp_stats[i].counter_checkpoints_iss;
 		system_stats->counter_recoveries   += lp_stats[i].counter_recoveries;
+		system_stats->counter_restore_iss  += lp_stats[i].counter_restore_iss;
 		system_stats->counter_rollbacks    += lp_stats[i].counter_rollbacks;
 		system_stats->counter_rollbacks_length    += lp_stats[i].counter_rollbacks_length;
 		system_stats->counter_prune        += lp_stats[i].counter_prune;
@@ -262,11 +284,14 @@ void gather_statistics() {
 		system_stats->clock_safety_check   += lp_stats[i].clock_safety_check;
 		system_stats->clock_silent         += lp_stats[i].clock_silent;
 		system_stats->clock_recovery       += lp_stats[i].clock_recovery;
+		system_stats->clock_recovery_iss   += lp_stats[i].clock_recovery_iss;
 		system_stats->clock_checkpoint     += lp_stats[i].clock_checkpoint;
 		system_stats->clock_rollback       += lp_stats[i].clock_rollback;
+		system_stats->clock_checkpoint_iss += lp_stats[i].clock_checkpoint_iss;
 
 		system_stats->mem_checkpoint       += lp_stats[i].mem_checkpoint;
 		system_stats->checkpoint_period    += lp_stats[i].checkpoint_period;
+		system_stats->mem_checkpoint_iss	 += lp_stats[i].mem_checkpoint_iss;
 		
 		system_stats->total_frames         += LPS[i]->num_executed_frames;
 	}
@@ -288,7 +313,9 @@ void gather_statistics() {
 	system_stats->clock_rollback     /= system_stats->counter_rollbacks;
 	system_stats->counter_rollbacks_length    += lp_stats[i].counter_rollbacks_length;
 	system_stats->clock_checkpoint   /= system_stats->counter_checkpoints;
+	system_stats->clock_checkpoint_iss   /= system_stats->counter_checkpoints;
 	system_stats->clock_recovery     /= system_stats->counter_recoveries;
+	system_stats->clock_recovery_iss     /= system_stats->counter_recoveries;
 
 	system_stats->clock_safe         /= (system_stats->events_total - system_stats->events_silent);
 	system_stats->clock_frame_tot     = system_stats->clock_safe * system_stats->total_frames;
@@ -301,6 +328,7 @@ void gather_statistics() {
 	system_stats->counter_checkpoint_recalc /= pdes_config.nprocesses;
 
 	system_stats->mem_checkpoint /= system_stats->counter_checkpoints;
+	system_stats->mem_checkpoint_iss /= system_stats->counter_checkpoints_iss;
 	system_stats->checkpoint_period /= pdes_config.nprocesses;
 }
 
@@ -359,8 +387,10 @@ static void _print_statistics(struct stats_t *stats) {
 	printf("\n");
 
 	printf("Save Checkpoint operations......................: %12llu\n", (unsigned long long)stats->counter_checkpoints);
+	printf("Save Incremental Checkpoint operations..........: %12llu\n", (unsigned long long)stats->counter_checkpoints_iss);
 	printf("Restore Checkpoint operations...................: %12llu\n", (unsigned long long)stats->counter_recoveries);
-	printf("Rollback operations.............................: %12llu\n", (unsigned long long)stats->counter_rollbacks);
+	printf("Incremental Restore Checkpoint operations.......: %12llu\n", (unsigned long long)stats->counter_restore_iss);
+  printf("Rollback operations.............................: %12llu\n", (unsigned long long)stats->counter_rollbacks);
 	printf("AVG Rollbacked Events...........................: %12.2f\n", stats->counter_rollbacks_length/stats->counter_rollbacks);
 	printf("CheckOnGVT invocations..........................: %12llu\n", (unsigned long long)stats->counter_ongvt);
 	
@@ -370,13 +400,18 @@ static void _print_statistics(struct stats_t *stats) {
         stats->clock_rollback, percentage(stats->clock_rollback,stats->clock_rollback));
 	printf("Save Checkpoint time............................: %12.2f clocks (%4.2f%%)\n",
 		stats->clock_checkpoint, percentage(stats->clock_checkpoint, stats->clock_rollback));
+	printf("Save Incremental Checkpoint time................: %12.2f clocks (%4.2f%%)\n",
+		stats->clock_checkpoint_iss, percentage(stats->clock_checkpoint_iss, stats->clock_rollback));
 	printf("Load Checkpoint time............................: %12.2f clocks (%4.2f%%)\n",
 		stats->clock_recovery, percentage(stats->clock_recovery, stats->clock_rollback));
+	printf("Load Incremental Checkpoint time................: %12.2f clocks (%4.2f%%)\n",
+		stats->clock_recovery_iss, percentage(stats->clock_recovery_iss, stats->clock_rollback));
 
 	printf("\n");
 
 
 	printf("Checkpoint mem..................................: %12u B\n", (unsigned int)stats->mem_checkpoint);
+	printf("Incremental Checkpoint mem......................: %12u B\n", (unsigned int)stats->mem_checkpoint_iss);
 	printf("Checkpoint recalculations.......................: %12llu\n", (unsigned long long)stats->counter_checkpoint_recalc);
 	printf("Checkpoint period...............................: %12llu\n", (unsigned long long)stats->checkpoint_period);
 
@@ -406,6 +441,8 @@ static void _print_statistics(struct stats_t *stats) {
 		(unsigned long long)(stats->events_enqueued*stats->clock_enqueue), percentage(stats->events_enqueued*stats->clock_enqueue,stats->clock_loop_tot));
 	printf("Save  Chkp Clocks.........................: %14llu clocks (%4.2f%%)\n", 
 		(unsigned long long)(stats->counter_checkpoints*stats->clock_checkpoint), percentage(stats->counter_checkpoints*stats->clock_checkpoint,stats->clock_loop_tot));
+	printf("Save Incremental Chkp Clocks..............: %14llu clocks (%4.2f%%)\n", 
+		(unsigned long long)(stats->counter_checkpoints_iss*stats->clock_checkpoint_iss), percentage(stats->counter_checkpoints_iss*stats->clock_checkpoint_iss,stats->clock_loop_tot));
 	printf("Load  Chkp Clocks.........................: %14llu clocks (%4.2f%%)\n", 
 		(unsigned long long)(stats->counter_rollbacks*stats->clock_rollback - (stats->clock_event_tot-stats->clock_safe_tot)), percentage(stats->counter_rollbacks*stats->clock_rollback - (stats->clock_event_tot-stats->clock_safe_tot),stats->clock_loop_tot));
 

--- a/src/statistics/statistics.h
+++ b/src/statistics/statistics.h
@@ -75,6 +75,12 @@
 #define STAT_ROLLBACK               305        /// Number of rollback operations
 #define STAT_ROLLBACK_LENGTH        306        /// Number of rollback operations
 #define STAT_ONGVT                  309        /// Average value of the checkpoint interval
+#define STAT_INC_CKPT               310        /// Number of incremental checkpoints 
+#define STAT_INC_CKPT_TIME          311        /// Average time to take an incremental checkpoint
+#define STAT_INC_CKPT_MEM           312        /// Average memory consumption used by an incremental checkpoint
+#define STAT_INC_RESTORE            313        /// Number of incremental restore
+#define STAT_INC_RECOVERY_TIME      314        /// Average time to restore an incremental checkpoint
+
 
 #define STAT_PRUNE_COUNTER          400        /// Number of pruning operations
 
@@ -103,6 +109,8 @@ struct stats_t {
     stat64_t counter_rollbacks_length;
     stat64_t counter_recoveries;
     stat64_t counter_checkpoints;
+    stat64_t counter_checkpoints_iss; //DSRT23
+    stat64_t counter_restore_iss; //DSRT23
     stat64_t counter_prune;
     stat64_t counter_safety_check;
     stat64_t counter_checkpoint_recalc;
@@ -125,11 +133,14 @@ struct stats_t {
     stat64_t clock_safe;	//PADS2018
     stat64_t clock_recovery;
     stat64_t clock_checkpoint;
+    stat64_t clock_checkpoint_iss; //DSRT23
+    stat64_t clock_recovery_iss; //DSRT23
     stat64_t clock_rollback;
     stat64_t clock_init;
 
     stat64_t mem_checkpoint;
     stat64_t checkpoint_period;
+    stat64_t mem_checkpoint_iss; //DSRT23
 
     stat64_t total_frames;
     

--- a/test/mm/incremental_state_saving.c
+++ b/test/mm/incremental_state_saving.c
@@ -61,7 +61,7 @@ static int iss_test(void)
 	unsigned int  counter = 0;
 	pdes_config.checkpointing = INCREMENTAL_STATE_SAVING;
 	pdes_config.ckpt_forced_full_period = 5;
-	pdes_config.iss_enabled_mprotection = 1;
+	pdes_config.iss_mode = 1;
 
 	init_incremental_checkpoint_support(1);
 	init_incremental_checkpoint_support_per_lp(0);


### PR DESCRIPTION
file (configuration.c, configuration.h) : added parameter mem_support_log to decide whether the ckpt system is supported by dymelor or not 
- 1 being supported by dymelor
- 0 being supported by buddy system

file(recoverable.c): edited log_size computation, adding dirty_bitmap's and dirty_areas' sizes

refactor(checkpoints.c): added support to incremental checkpointing using dirty_bitmap and refactored code
- compute_bitmap_blocks: computes the occupancy of chunks in a m_area given the area and the type of chunks (num_chunks, dirty_chunks..)
- clean_bitmap: resets a bitmap
- log_dirty_marea_chunks: copies the dirty blocks
- restore_dirty_marea_chunks: restores the dirty blocks