### PR TITLE
Pseudo di dymelor pt 2

### DIFF
--- a/src/core/configuration.c
+++ b/src/core/configuration.c
@@ -51,6 +51,7 @@ static struct argp_option options[] = {
   {"ckpt-fossil-period",  CKPT_FOSSIL_PERIOD_KEY   , "#EVENTS" ,  0                  ,  "Number of events to be executed before collection committed snapshot"   , 0 },
   {"ckpt-autonomic-period",  CKPT_AUTONOMIC_PERIOD_KEY, 0         ,  OPTION_ARG_OPTIONAL,  "Enable autonomic checkpointing period"   , 0 },
   {"ckpt_forced_full_period",  CKPT_FORCED_FULL_PERIOD_KEY, "#CHECKPOINTS"         ,  0,  "Number of incremental checkpoints before taking a full log"   , 0 },
+  {"iss_enabled",                ISS_ENABLED ,         0        ,  OPTION_ARG_OPTIONAL,  "Use mprotect as tracking mechanism for write accesses"   , 0 },
   {"iss_mode",                ISS_MODE ,         0        ,  OPTION_ARG_OPTIONAL,  "Use mprotect as tracking mechanism for write accesses"   , 0 },
 
   {"distributed-fetch",   DISTRIBUTED_FETCH_KEY    , 0         ,  OPTION_ARG_OPTIONAL,  "Enable distributed fetch"   , 0 },
@@ -97,8 +98,11 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       pdes_config.ckpt_autonomic_period = 1;
       break;
 
-    case ISS_MODE:
+    case ISS_ENABLED:
       pdes_config.checkpointing = INCREMENTAL_STATE_SAVING;
+      break;
+
+    case ISS_MODE:
       pdes_config.iss_mode = MPROTECT;
       break;
 

--- a/src/include/ROOT-Sim.h
+++ b/src/include/ROOT-Sim.h
@@ -149,10 +149,10 @@ extern void dirty(void*, size_t);
 		if(pdes_config.checkpointing == INCREMENTAL_STATE_SAVING){\
 			if (pdes_config.iss_mode == MPROTECT) {\
 				do{ dirty(&(var), sizeof((var))); (var) = (val); } while(0);\
-			}\
-		} else {\
+			} else {\
 				do { set_chunk_dirty_from_address(&(var), val); (var) = (val); } while(0);\
 			}\
+		}\
 	})
 
 

--- a/src/include/ROOT-Sim.h
+++ b/src/include/ROOT-Sim.h
@@ -144,17 +144,16 @@ int Zipf(double skew, int limit);
 
 
 extern void dirty(void*, size_t);
-extern void set_chunk_dirty_from_address(void *, int);
 
 #define MODEL_WRITE(var,val)({\
 		if(pdes_config.checkpointing == INCREMENTAL_STATE_SAVING){\
 			if (pdes_config.iss_mode == MPROTECT) {\
-				do{ dirty(&(var), sizeof((var)));(var) = (val);} while(0);\
-			}else {\
-				do { set_chunk_dirty_from_address(&(var), val); (var) = (val); } while (0);\
+				do{ dirty(&(var), sizeof((var))); (var) = (val); } while(0);\
 			}\
-		}\
-		})
+		} else {\
+				do { set_chunk_dirty_from_address(&(var), val); (var) = (val); } while(0);\
+			}\
+	})
 
 
 

--- a/src/mm/recoverable.c
+++ b/src/mm/recoverable.c
@@ -113,7 +113,7 @@ size_t get_log_size(malloc_state *logged_state){
 		if (pdes_config.iss_mode == DDYMELOR) {
 			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->dirty_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->dirty_bitmap_size + logged_state->total_inc_size;
 		} else {
-			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + sizeof(void *);
+			log_size = sizeof(malloc_state) + sizeof(seed_type) + logged_state->busy_areas * sizeof(malloc_area) + logged_state->bitmap_size + logged_state->total_log_size + sizeof(void *);
 		}
 	}
 


### PR DESCRIPTION
file (recoverable.c) : corrected log_size when we use mprotection → added total_log_size
*** if is_incremental is forced to true without iss_mode ckpt size is wrong by -176 bytes

file (ROOT-Sim.h): corrected if-else branch in MODEL_WRITE, the else is now referred to the initial if checkpointing == incremental_state_saving, otherwise it would always be false since incremental_state_saving and mprotect are coupled in configuration