### PR TITLE
script for generating diff file between two .tex files

### DIFF
--- a/reproducibility/TOMACS2023/texdiff.sh
+++ b/reproducibility/TOMACS2023/texdiff.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+unzip -q -d ./tomacs-tex-files "TOMACS-Spatial and temporal locality-2023.zip"
+
+cd tomacs-tex-files
+
+latexdiff ./backup/versione-prima-sottomissione.tex revisione.tex > diff.tex 
+#pdflatex ./diff.tex


### PR DESCRIPTION
the script unzips an archive and then creates a diff file between the current .tex version (revision.tex) and the first one (versione-prima-sottomissione.tex)

it does not create the pdf file (it's created through texmaker but not through pdftex, pdftlatex et similia)

the zipped archive must be in USE/reproducibility/TOMACS2023/